### PR TITLE
Fix content_type checking bug and use paperclip check logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_deploy:
+  - gem install mime-types -v 2.6.2
 rvm:
   - 1.9.3
   - 2.2.2

--- a/file_validators.gemspec
+++ b/file_validators.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel', '>= 3.0'
   s.add_dependency 'mime-types', '>= 1.0'
+  s.add_dependency('mimemagic', '0.3.0')
+  s.add_dependency('cocaine', '~> 0.5.5')
 
-  s.add_development_dependency 'cocaine', '~> 0.5.4'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.1.0'
   s.add_development_dependency 'coveralls'

--- a/file_validators.gemspec
+++ b/file_validators.gemspec
@@ -17,8 +17,14 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^spec/})
   s.require_paths  = ['lib']
 
+  # ruby < 2.0 only supports mime-types <= 2.6.2
+  if RUBY_VERSION < '2.0'
+    s.add_dependency 'mime-types', [ '>= 2.6.2', '< 3' ]
+  else
+    s.add_dependency 'mime-types', '>= 1.0'
+  end
+
   s.add_dependency 'activemodel', '>= 3.0'
-  s.add_dependency 'mime-types', '>= 1.0'
   s.add_dependency('mimemagic', '0.3.0')
   s.add_dependency('cocaine', '~> 0.5.5')
 

--- a/lib/file_validators.rb
+++ b/lib/file_validators.rb
@@ -1,4 +1,6 @@
 require 'active_model'
+require 'mimemagic'
+require 'mimemagic/overlay'
 require 'file_validators/validators/file_size_validator'
 require 'file_validators/validators/file_content_type_validator'
 

--- a/lib/file_validators/utils/content_type_detector.rb
+++ b/lib/file_validators/utils/content_type_detector.rb
@@ -48,7 +48,7 @@ module FileValidators
       alias :empty? :empty_file?
 
       def blank_name?
-        @filepath.nil? || @filepath.try(:empty?)
+        @filepath.nil? || @filepath.empty?
       end
 
       def file_exists?

--- a/lib/file_validators/utils/content_type_detector.rb
+++ b/lib/file_validators/utils/content_type_detector.rb
@@ -68,7 +68,7 @@ module FileValidators
       def type_from_file_contents
         type_from_mime_magic || type_from_file_command
       rescue Errno::ENOENT => e
-        Paperclip.log("Error while determining content type: #{e}")
+        puts "Error while determining content type: #{e}"
         SENSIBLE_DEFAULT
       end
 

--- a/lib/file_validators/utils/file_command_content_type_detector.rb
+++ b/lib/file_validators/utils/file_command_content_type_detector.rb
@@ -1,0 +1,38 @@
+begin
+  require 'cocaine'
+rescue LoadError
+end
+
+module FileValidators
+  module Utils
+
+    class FileCommandContentTypeDetector
+      SENSIBLE_DEFAULT = "application/octet-stream"
+
+      def initialize(filename)
+        @filename = filename
+      end
+
+      def detect
+        type_from_file_command
+      end
+
+      private
+
+      def type_from_file_command
+        # On BSDs, `file` doesn't give a result code of 1 if the file doesn't exist.
+        type = begin
+          Cocaine::CommandLine.new('file', '-b --mime-type :file').run(file: @filename)
+        rescue Cocaine::CommandLineError => e
+          puts "file_validators: Add 'cocaine' gem as you are using file content type validations in strict mode"
+          SENSIBLE_DEFAULT
+        end
+
+        if type.nil? || type.match(/\(.*?\)/)
+          type = SENSIBLE_DEFAULT
+        end
+        type.split(/[:;\s]+/)[0]
+      end
+    end
+  end
+end

--- a/lib/file_validators/validators/file_content_type_validator.rb
+++ b/lib/file_validators/validators/file_content_type_validator.rb
@@ -1,5 +1,6 @@
 require 'file_validators/utils/content_type_detector'
 require 'file_validators/utils/media_type_spoof_detector'
+require 'file_validators/utils/file_command_content_type_detector'
 
 module ActiveModel
   module Validations
@@ -40,8 +41,10 @@ module ActiveModel
       private
 
       def get_file_path(value)
-        if value.try(:path)
-          value.path
+        temp_object = value.try(:tempfile) || Paperclip.io_adapters.for(value)
+
+        if temp_object.respond_to?(:path)
+          temp_object.path
         else
           raise ArgumentError, 'value must return a file path in order to validate file content type'
         end

--- a/spec/lib/file_validators/utils/content_type_detector_spec.rb
+++ b/spec/lib/file_validators/utils/content_type_detector_spec.rb
@@ -4,7 +4,7 @@ require 'tempfile'
 describe FileValidators::Utils::ContentTypeDetector do
   it 'returns the empty content type when the file is empty' do
     tempfile = Tempfile.new('empty')
-    expect(FileValidators::Utils::ContentTypeDetector.new(tempfile).detect).to eql('inode/x-empty')
+    expect(FileValidators::Utils::ContentTypeDetector.new(tempfile.path).detect).to eql('inode/x-empty')
     tempfile.close
   end
 


### PR DESCRIPTION
Hi,

This fixes a bug which meant FileValidators::Utils content_type_from_command was not processing the temp file correctly and the file utility was returning 
```
=> "cannot open `/my_file_path/something.txt' (No such file or directory)"
```

because the file does not exist at the point of validation.

It also uses the logic implemented in paperclip [here](https://github.com/thoughtbot/paperclip/blob/523bd46c768226893f23889079a7aa9c73b57d68/lib/paperclip/content_type_detector.rb)