### PR TITLE
Support carrierwave multiple file uploads

### DIFF
--- a/spec/integration/file_content_type_validation_integration_spec.rb
+++ b/spec/integration/file_content_type_validation_integration_spec.rb
@@ -379,4 +379,54 @@ describe 'File Content Type integration with ActiveModel' do
       it { is_expected.to be_valid }
     end
   end
+
+  context 'image data as array' do
+    before :all do
+      Person.class_eval do
+        Person.reset_callbacks(:validate)
+        validates :avatar, file_content_type: { allow: 'image/jpeg' }
+      end
+    end
+
+    subject { Person.new }
+
+    context 'for one invalid content type' do
+      before {
+        subject.avatar = [
+          Rack::Test::UploadedFile.new(@sample_text_path, 'text/plain'),
+          Rack::Test::UploadedFile.new(@cute_path, 'image/jpeg')
+        ]
+      }
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'for two invalid content types' do
+      before {
+        subject.avatar = [
+          Rack::Test::UploadedFile.new(@sample_text_path, 'text/plain'),
+          Rack::Test::UploadedFile.new(@sample_text_path, 'text/plain')
+        ]
+      }
+
+      it 'is invalid and adds just one error' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.count).to eq 1
+      end
+    end
+
+    context 'for valid content type' do
+      before {
+        subject.avatar = [
+          Rack::Test::UploadedFile.new(@cute_path, 'image/jpeg'),
+          Rack::Test::UploadedFile.new(@cute_path, 'image/jpeg')
+        ]
+      }
+      it { is_expected.to be_valid }
+    end
+
+    context 'empty array' do
+      before { subject.avatar = [] }
+      it { is_expected.to be_valid }
+    end
+  end
 end


### PR DESCRIPTION
Solves #14 

Latest carrierwave (v1.0.0.rc) supports multiple file uploads. 
https://github.com/carrierwaveuploader/carrierwave#multiple-file-uploads

Before there was just one CarrierWave::Uploader::Base object in the validated field's value. Now the field's value contains an array of CarrierWave::Uploader::Base objects (which can be empty, contain one item or many items).

When the validated field's value is an array, **all** the files it contains must pass the validation. If there is just one invalid file, an error message is added to the field.

Works with both file size and content type (gem tests are green, I tried file size validator on a real project, but haven't tried content type validator).

Note: Two tests were failing on my machine when I cloned master. They are still failing.

```
rspec ./spec/lib/file_validators/utils/content_type_detector_spec.rb:19 # FileValidators::Utils::ContentTypeDetector returns a sensible default when the file path is empty
rspec ./spec/lib/file_validators/utils/content_type_detector_spec.rb:23 # FileValidators::Utils::ContentTypeDetector returns a sensible default if the file path is invalid

```
Idea: I kept it simple this time and didn't bother with error messages, but I can imagine adding a different error message when there are multiple files or adding one error message per each file (including file name). 