### PR TITLE
Avoid blank size

### DIFF
--- a/lib/file_validators/validators/file_size_validator.rb
+++ b/lib/file_validators/validators/file_size_validator.rb
@@ -58,6 +58,7 @@ module ActiveModel
       end
 
       def valid_size?(size, option, option_value)
+        return false if size.nil?
         if option_value.is_a?(Range)
           option_value.send(CHECKS[option], size)
         else

--- a/spec/lib/file_validators/validators/file_size_validator_spec.rb
+++ b/spec/lib/file_validators/validators/file_size_validator_spec.rb
@@ -168,6 +168,12 @@ describe ActiveModel::Validations::FileSizeValidator do
     end
   end
 
+  context 'exceptional file size' do
+    before { build_validator less_than: 3.kilobytes }
+
+    it { is_expected.to allow_file_size(0, @validator) } # zero-byte file
+    it { is_expected.not_to allow_file_size(nil, @validator) }
+  end
 
   context 'using the helper' do
     before { Dummy.validates_file_size :avatar, in: (5.kilobytes..10.kilobytes) }


### PR DESCRIPTION
Hey there. Thanks for supporting this gem 👍 

From time to time we experience the following error thrown in `file_size_validator` (see backtrace below).  The issue happens when a file is removed, so the size returned in parameters is `nil`. We use `grid_fs` storage in mongoid to store files, but that can probably happen with other kinds of storages as well.

This small change is just about to avoid `NoMethodError` here.

Ruby version: `2.4.1p111`
Gem version: `2.1.0`.

```
undefined method `<' for nil:NilClass
  file_validators (2.1.0) lib/file_validators/validators/file_size_validator.rb:54:in `valid_size?'
  file_validators (2.1.0) lib/file_validators/validators/file_size_validator.rb:21:in `block in validate_each'
  file_validators (2.1.0) lib/file_validators/validators/file_size_validator.rb:18:in `each'
  file_validators (2.1.0) lib/file_validators/validators/file_size_validator.rb:18:in `validate_each'
  activemodel (5.0.2) lib/active_model/validator.rb:151:in `block in validate'
  activemodel (5.0.2) lib/active_model/validator.rb:148:in `each'
  activemodel (5.0.2) lib/active_model/validator.rb:148:in `validate'
  activesupport (5.0.2) lib/active_support/callbacks.rb:405:in `public_send'
  activesupport (5.0.2) lib/active_support/callbacks.rb:405:in `block in make_lambda'
  activesupport (5.0.2) lib/active_support/callbacks.rb:150:in `call'
  activesupport (5.0.2) lib/active_support/callbacks.rb:150:in `block (2 levels) in halting_and_conditional'
  activesupport (5.0.2) lib/active_support/callbacks.rb:547:in `call'
  activesupport (5.0.2) lib/active_support/callbacks.rb:547:in `block (2 levels) in default_terminator'
  activesupport (5.0.2) lib/active_support/callbacks.rb:546:in `catch'
  activesupport (5.0.2) lib/active_support/callbacks.rb:546:in `block in default_terminator'
  activesupport (5.0.2) lib/active_support/callbacks.rb:151:in `call'
  activesupport (5.0.2) lib/active_support/callbacks.rb:151:in `block in halting_and_conditional'
  activesupport (5.0.2) lib/active_support/callbacks.rb:454:in `call'
  activesupport (5.0.2) lib/active_support/callbacks.rb:454:in `block in call'
  activesupport (5.0.2) lib/active_support/callbacks.rb:454:in `each'
  activesupport (5.0.2) lib/active_support/callbacks.rb:454:in `call'
  activesupport (5.0.2) lib/active_support/callbacks.rb:101:in `__run_callbacks__'
  activesupport (5.0.2) lib/active_support/callbacks.rb:750:in `_run_validate_callbacks'
  activemodel (5.0.2) lib/active_model/validations.rb:408:in `run_validations!'
  activemodel (5.0.2) lib/active_model/validations/callbacks.rb:113:in `block in run_validations!'
  activesupport (5.0.2) lib/active_support/callbacks.rb:97:in `__run_callbacks__'
  activesupport (5.0.2) lib/active_support/callbacks.rb:750:in `_run_validation_callbacks'
  activemodel (5.0.2) lib/active_model/validations/callbacks.rb:113:in `run_validations!'
  activemodel (5.0.2) lib/active_model/validations.rb:338:in `valid?'
  mongoid (6.1.0) lib/mongoid/validatable.rb:97:in `valid?'
  activemodel (5.0.2) lib/active_model/validations.rb:375:in `invalid?'
  mongoid (6.1.0) lib/mongoid/persistable/updatable.rb:108:in `prepare_update'
  mongoid (6.1.0) lib/mongoid/persistable/updatable.rb:132:in `update_document'
  mongoid (6.1.0) lib/mongoid/persistable/savable.rb:25:in `save'
  mongoid (6.1.0) lib/mongoid/persistable/updatable.rb:46:in `update'
```
