### PR TITLE
Switch to use 'ruby-filemagic' instead of Cocaine + 'file'

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ It will not allow a file having `image/jpeg` content type to be saved as `text/p
 type mismatch, for example `text` of `text/plain` and `image` of `image/jpeg`. So it will not prevent
 `image/jpeg` from saving as `image/png` as both have the same `image` media type.
 
-**note**: This security feature is disabled by default. To enable it, first add `cocaine` gem in
+**note**: This security feature is disabled by default. To enable it, first add `ruby-filemagic` gem in
 your Gemfile and then add `mode: :strict` option in [content type validations](#file-content-type-validator).
 `:strict` mode may not work in direct file uploading systems as the file is not passed along with the form.
 

--- a/file_validators.gemspec
+++ b/file_validators.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemodel', '>= 3.2'
   s.add_dependency 'mime-types', '>= 1.0'
 
-  s.add_development_dependency 'cocaine', '~> 0.5.4'
+  s.add_development_dependency 'ruby-filemagic', '>= 0.7.2'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.5.0'
   s.add_development_dependency 'coveralls'

--- a/lib/file_validators/utils/content_type_detector.rb
+++ b/lib/file_validators/utils/content_type_detector.rb
@@ -1,9 +1,9 @@
 require 'logger'
 
 begin
-  require 'cocaine'
+  require 'filemagic'
 rescue LoadError
-  puts "file_validators requires 'cocaine' gem as you are using file content type validations in strict mode"
+  puts "file_validators requires 'filemagic' gem as you are using file content type validations in strict mode"
 end
 
 module FileValidators
@@ -50,11 +50,9 @@ module FileValidators
       end
 
       def type_from_file_command
-        begin
-          Cocaine::CommandLine.new('file', '-b --mime-type :file').run(file: @file_path).strip
-        rescue Cocaine::CommandLineError => e
-          logger.info(e.message)
-          DEFAULT_CONTENT_TYPE
+        FileMagic.open(:mime) do |fm|
+          fm.flags = [:mime_type]
+          fm.file @file_path
         end
       end
 


### PR DESCRIPTION
As I see in https://github.com/musaffa/file_validators/issues/24 you desire to switch from Cocaine.

Probably it is what you are looking fore.
ruby-filemagic using same 'file' command functionality.
Also I see surprising porting it to other platforms through Docker.