### PR TITLE
Fix JSON::ParserError when image data is an invalid json string

### DIFF
--- a/lib/file_validators/validators/file_content_type_validator.rb
+++ b/lib/file_validators/validators/file_content_type_validator.rb
@@ -10,12 +10,12 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        values = begin
-                   parse_values(value)
-                 rescue JSON::ParserError
-                   record.errors.add attribute, :invalid
-                   []
-                 end
+        begin
+          values = parse_values(value)
+        rescue JSON::ParserError
+          record.errors.add attribute, :invalid
+          return
+        end
 
         return if values.empty?
 

--- a/lib/file_validators/validators/file_content_type_validator.rb
+++ b/lib/file_validators/validators/file_content_type_validator.rb
@@ -22,6 +22,8 @@ module ActiveModel
           validate_whitelist(record, attribute, content_type, allowed_types)
           validate_blacklist(record, attribute, content_type, forbidden_types)
         end
+      rescue JSON::ParserError
+        record.errors.add attribute, :invalid
       end
 
       def check_validity!

--- a/lib/file_validators/validators/file_content_type_validator.rb
+++ b/lib/file_validators/validators/file_content_type_validator.rb
@@ -10,7 +10,13 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        values = parse_values(value)
+        values = begin
+                   parse_values(value)
+                 rescue JSON::ParserError
+                   record.errors.add attribute, :invalid
+                   []
+                 end
+
         return if values.empty?
 
         mode = option_value(record, :mode)
@@ -22,8 +28,6 @@ module ActiveModel
           validate_whitelist(record, attribute, content_type, allowed_types)
           validate_blacklist(record, attribute, content_type, forbidden_types)
         end
-      rescue JSON::ParserError
-        record.errors.add attribute, :invalid
       end
 
       def check_validity!

--- a/lib/file_validators/validators/file_size_validator.rb
+++ b/lib/file_validators/validators/file_size_validator.rb
@@ -14,14 +14,18 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        values = parse_values(value)
+        values = begin
+                   parse_values(value)
+                 rescue JSON::ParserError
+                   record.errors.add attribute, :invalid
+                   []
+                 end
+
         return if values.empty?
 
         options.slice(*CHECKS.keys).each do |option, option_value|
           check_errors(record, attribute, values, option, option_value)
         end
-      rescue JSON::ParserError
-        record.errors.add attribute, :invalid
       end
 
       def check_validity!

--- a/lib/file_validators/validators/file_size_validator.rb
+++ b/lib/file_validators/validators/file_size_validator.rb
@@ -14,12 +14,12 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        values = begin
-                   parse_values(value)
-                 rescue JSON::ParserError
-                   record.errors.add attribute, :invalid
-                   []
-                 end
+        begin
+          values = parse_values(value)
+        rescue JSON::ParserError
+          record.errors.add attribute, :invalid
+          return
+        end
 
         return if values.empty?
 

--- a/lib/file_validators/validators/file_size_validator.rb
+++ b/lib/file_validators/validators/file_size_validator.rb
@@ -20,6 +20,8 @@ module ActiveModel
         options.slice(*CHECKS.keys).each do |option, option_value|
           check_errors(record, attribute, values, option, option_value)
         end
+      rescue JSON::ParserError
+        record.errors.add attribute, :invalid
       end
 
       def check_validity!

--- a/spec/integration/file_content_type_validation_integration_spec.rb
+++ b/spec/integration/file_content_type_validation_integration_spec.rb
@@ -365,7 +365,7 @@ describe 'File Content Type integration with ActiveModel' do
       it { is_expected.to be_valid }
     end
 
-    context 'invalid string' do
+    context 'invalid json string' do
       before { subject.avatar = '\'' }
       it { is_expected.not_to be_valid }
     end

--- a/spec/integration/file_content_type_validation_integration_spec.rb
+++ b/spec/integration/file_content_type_validation_integration_spec.rb
@@ -364,6 +364,11 @@ describe 'File Content Type integration with ActiveModel' do
       before { subject.avatar = '' }
       it { is_expected.to be_valid }
     end
+
+    context 'invalid string' do
+      before { subject.avatar = '\'' }
+      it { is_expected.not_to be_valid }
+    end
   end
 
   context 'image data as hash' do

--- a/spec/integration/file_content_type_validation_integration_spec.rb
+++ b/spec/integration/file_content_type_validation_integration_spec.rb
@@ -366,7 +366,7 @@ describe 'File Content Type integration with ActiveModel' do
     end
 
     context 'invalid json string' do
-      before { subject.avatar = '\'' }
+      before { subject.avatar = '{filename":"img140910_88338.jpg","content_type":"image/jpeg","size":13150}' }
       it { is_expected.not_to be_valid }
     end
   end

--- a/spec/integration/file_size_validator_integration_spec.rb
+++ b/spec/integration/file_size_validator_integration_spec.rb
@@ -244,6 +244,11 @@ describe 'File Size Validator integration with ActiveModel' do
       before { subject.avatar = '' }
       it { is_expected.to be_valid }
     end
+
+    context 'invalid string' do
+      before { subject.avatar = '\'' }
+      it { is_expected.not_to be_valid }
+    end
   end
 
   context 'image data as hash' do

--- a/spec/integration/file_size_validator_integration_spec.rb
+++ b/spec/integration/file_size_validator_integration_spec.rb
@@ -240,7 +240,7 @@ describe 'File Size Validator integration with ActiveModel' do
       it { is_expected.to be_valid }
     end
 
-    context 'empty json string' do
+    context 'empty string' do
       before { subject.avatar = '' }
       it { is_expected.to be_valid }
     end

--- a/spec/integration/file_size_validator_integration_spec.rb
+++ b/spec/integration/file_size_validator_integration_spec.rb
@@ -245,7 +245,7 @@ describe 'File Size Validator integration with ActiveModel' do
       it { is_expected.to be_valid }
     end
 
-    context 'invalid string' do
+    context 'invalid json string' do
       before { subject.avatar = '\'' }
       it { is_expected.not_to be_valid }
     end

--- a/spec/integration/file_size_validator_integration_spec.rb
+++ b/spec/integration/file_size_validator_integration_spec.rb
@@ -246,7 +246,7 @@ describe 'File Size Validator integration with ActiveModel' do
     end
 
     context 'invalid json string' do
-      before { subject.avatar = '\'' }
+      before { subject.avatar = '{filename":"img140910_88338.GIF","content_type":"image/gif","size":33150}' }
       it { is_expected.not_to be_valid }
     end
   end


### PR DESCRIPTION
Hello,

This pull request should fix the `JSON::ParserError` raised when one of the validator is fed with an invalid JSON string (issue #20).

Talking about validations, you always have to decide wether something will be considered valid or not. I choose to handle invalid JSON strings as invalid values and to add an error to the record. That's why are exceptions are rescued at this level instead of in the `parse_values` methods of each validator: I needed the record and attribute to add the error and did not want to pass them to `parse_values`.

The error message use the default `:invalid` message, as there's no need to be more precise. Invalid JSON string are not common things and are mostly due to nasty bots trying to break in an application. I don't think we need to be more explicit on this.

I hope you'll find the time to merge this soon.

Thanks